### PR TITLE
Always commit on clean branch

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,13 +72,17 @@ jobs:
                 git config user.name "github-actions"
                 git config user.email "github-actions@github.com"
 
+                # Checkout and sync with origin/main
+                git fetch origin
+                git checkout -B main origin/main
+
                 git add coverage.svg badge-ML-test-score.svg
-                
+
                 if git diff --cached --quiet; then
                   echo "No changes to commit"
                 else
                   git commit -m "Update coverage and ML test score badges [skip ci]"
-                  git pull --rebase origin main
-                  git push origin HEAD:main
+                  git push origin main
                 fi
+
 


### PR DESCRIPTION
Most work was done directly on main for debugging purposes. In the end, the workflows all passed for model-training, and we got a final automatic release out. This commit shows only the last step made to clean things up and get the PR requirement.